### PR TITLE
[feature] Add Timer to the Goban View

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,5 +3,6 @@
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
 //= link manifest.json
+//= link manifest.json.erb
 //= link popper.js
 //= link bootstrap.min.js

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -9,11 +9,15 @@ class GamesController < ApplicationController
     opponent_color = @color == "black" ? "white" : "black"
     @current_captured_stones = @game.score_for(@color)
     @opponent_captured_stones = @game.score_for(opponent_color)
+    @current_timer = @game.timer_for(@color)
+    @opponent_timer = @game.timer_for(opponent_color)
 
     if current_player == @currently_playing
       @message = "A vous de jouer"
+      @playing = true
     else
       @message = "C'est à votre adversaire de jouer"
+      @playing = false
     end
   end
 

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -1,6 +1,6 @@
-import { createConsumer } from "@rails/actioncable";
+import {createConsumer} from "@rails/actioncable";
 
-import { Controller } from "@hotwired/stimulus"
+import {Controller} from "@hotwired/stimulus"
 
 // Connects to data-controller="game"
 export default class extends Controller {
@@ -12,9 +12,13 @@ export default class extends Controller {
   connect() {
     this.channel = createConsumer().subscriptions.create(
       {channel: "GameChannel", gameid: this.gameidValue, playerid: this.playeridValue},
-      {received: (data) => {
-        Turbo.renderStreamMessage(data.html)
-      }}
+      {
+        received: (data) => {
+          window["opponent-timerController"].stop()
+          window['current-timerController'].start()
+          Turbo.renderStreamMessage(data.html)
+        }
+      }
     )
   }
 }

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -1,0 +1,57 @@
+import {Controller} from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    minutes: Number,
+    seconds: Number,
+    isPlaying: Boolean
+  }
+
+  connect() {
+    window[`${this.element.id}Controller`] = this
+
+    this.timer = null
+    this.remainingTime = (this.minutesValue * 60) + this.secondsValue
+
+    if (this.isPlayingValue) {
+      this.start()
+    }
+  }
+
+  disconnect() {
+    window.timerController = null
+    this.stop()
+  }
+
+  start() {
+    if (this.timer) return
+
+    this.timer = setInterval(() => {
+      this.remainingTime--
+
+      if (this.remainingTime <= 0) {
+        this.stop()
+        // TODO : Fetch GameOver
+      }
+
+      this.#updateDisplay()
+    }, 1000)
+  }
+
+  stop() {
+    if (!this.timer) return
+
+    clearInterval(this.timer)
+    this.timer = null
+  }
+
+  #updateDisplay() {
+    const minutes = Math.floor(this.remainingTime / 60)
+    const seconds = this.remainingTime % 60
+
+    const formattedMinutes = minutes.toString().padStart(2, '0')
+    const formattedSeconds = seconds.toString().padStart(2, '0')
+
+    this.element.textContent = `${formattedMinutes}:${formattedSeconds}`
+  }
+}

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -16,14 +16,29 @@ class Game < ApplicationRecord
     return white_player
   end
 
-  def score_for(color)
+  def turns_for(color)
     if color == "black"
       turns.select { |t| t.turn_number.odd? }
-           .sum(&:score)
     else
       turns.select { |t| t.turn_number.even? }
-           .sum(&:score)
     end
+  end
+
+  def score_for(color)
+    turns_for(color).sum(&:score)
+  end
+
+  def timer_for(color)
+    # 5 minutes' games
+    raw_seconds = 300 - turns_for(color).sum(&:duration)
+    minutes = raw_seconds / 60
+    seconds = raw_seconds % 60
+
+    {
+      minutes: minutes,
+      seconds: seconds,
+      string: format("%02d:%02d", minutes, seconds)
+    }
   end
 
   def currently_waiting
@@ -56,7 +71,7 @@ class Game < ApplicationRecord
     # je prends leur groupe
     opponent_neighbours.each do |s|
       group = goban.group(s)
-      next unless goban.liberty_count(group) == 0
+      next unless goban.liberty_count(group).zero?
 
       group.each do |stone|
         stones_to_remove << stone

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -1,11 +1,22 @@
 class Turn < ApplicationRecord
   belongs_to :game
 
+  before_save :set_duration
+
   def color
     if turn_number.odd?
       return "black"
     else
       return "white"
     end
+  end
+
+  def set_duration
+    end_of_turn = created_at || Time.now
+    self.duration = if turn_number == 1
+                      (end_of_turn - game.created_at).round
+                    else
+                      (end_of_turn - game.turns.find_by(turn_number: turn_number - 1).created_at).round
+                    end
   end
 end

--- a/app/views/games/_current_player.html.erb
+++ b/app/views/games/_current_player.html.erb
@@ -13,7 +13,13 @@
 
 
     <div class="timer-container">
-      <p class="timer" id="current-timer">02:58</p>
+      <p class="timer"
+         id="current-timer"
+         data-controller="timer"
+         data-timer-minutes-value="<%= current_timer[:minutes] %>"
+         data-timer-seconds-value="<%= current_timer[:seconds] %>"
+         data-timer-is-playing-value="<%= playing %>"
+      ><%= current_timer[:string] %></p>
     </div>
   </div>
 

--- a/app/views/games/_opponent.html.erb
+++ b/app/views/games/_opponent.html.erb
@@ -5,7 +5,13 @@
   <div class="col-12 mt-3 d-flex justify-content-between align-items-center">
     <!-- Timer à gauche -->
     <div class="timer-container">
-      <p class="timer" id="opponent-timer">03:00</p>
+      <p class="timer"
+         id="opponent-timer"
+         data-controller="timer"
+         data-timer-minutes-value="<%= opponent_timer[:minutes] %>"
+         data-timer-seconds-value="<%= opponent_timer[:seconds] %>"
+         data-timer-is-playing-value="<%= !playing %>"
+      ><%= opponent_timer[:string] %></p>
     </div>
 
     <div class="opponent-info d-flex align-items-center">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,13 +9,13 @@
     <%= render "games/header" %>
 
     <!-- Opponent -->
-    <%= render "games/opponent", opponent_captured_stones: @opponent_captured_stones %>
+    <%= render "games/opponent", playing: @playing, opponent_captured_stones: @opponent_captured_stones, opponent_timer: @opponent_timer %>
 
     <!-- Goban (plateau de jeu) -->
     <%= render "games/goban", game: @game, goban: @goban, color: @color %>
 
     <!-- Current Player -->
-    <%= render "games/current_player", current_captured_stones: @current_captured_stones %>
+    <%= render "games/current_player", playing: @playing, current_captured_stones: @current_captured_stones, current_timer: @current_timer %>
 
     <!-- referee -->
     <%= render "games/referee", message: @message %>

--- a/db/migrate/20241206021821_add_duration_to_turns.rb
+++ b/db/migrate/20241206021821_add_duration_to_turns.rb
@@ -1,0 +1,5 @@
+class AddDurationToTurns < ActiveRecord::Migration[7.2]
+  def change
+    add_column :turns, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_02_091005) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_021821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -113,6 +113,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_02_091005) do
     t.bigint "game_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "duration"
     t.index ["game_id"], name: "index_turns_on_game_id"
   end
 


### PR DESCRIPTION
## Context
For the demo to be a success, let's add swiftly the timers on your game view!

## Description
* `Turn` has now a duration, computed on `save`: it's the time in seconds between the `created_at` of the previous turn and this one
  * SPECIAL CASE: First turn is compared to `created_at` from the `game`
  * SPECIAL CASE: While the turn is not saved, `DateTime.now` is used instead of its `created_at`
*  `Game#timer_for` can now sum the duration of `turns` of a given `color`, and thus compose a timer
  * The given timer is 5 minutes (300 seconds) for now, you may want to change it later
  * It returns an `Hash`, with the timer seconds, the timer minutes and a string of those with padding 0s`
* `GamesController#Show` now sets a `@playing` variable instance to know which timer to start in the view, and the timer from the model
* A Stimulus Controller has been added to count down!

## Example

https://github.com/user-attachments/assets/84853ab4-86d8-471d-bfa2-51165a059812

